### PR TITLE
Usar modelos en plural

### DIFF
--- a/default/app/controllers/establishments_controller.php
+++ b/default/app/controllers/establishments_controller.php
@@ -4,6 +4,6 @@ class EstablishmentsController extends AppController {
         $cond = "is_active=1";
         if ($category) { $cond .= " AND category='".addslashes($category)."'"; }
         $this->category = $category;
-        $this->establishments = (new Establishment)->find("conditions: $cond", "order: name ASC");
+        $this->establishments = (new Establishments)->find("conditions: $cond", "order: name ASC");
     }
 }

--- a/default/app/controllers/events_controller.php
+++ b/default/app/controllers/events_controller.php
@@ -1,6 +1,6 @@
 <?php
 class EventsController extends AppController {
     public function index() {
-        $this->events = (new Event)->find("conditions: status='published'", "order: start_date DESC");
+        $this->events = (new Events)->find("conditions: status='published'", "order: start_date DESC");
     }
 }

--- a/default/app/controllers/gallery_controller.php
+++ b/default/app/controllers/gallery_controller.php
@@ -1,6 +1,6 @@
 <?php
 class GalleryController extends AppController {
     public function index() {
-        $this->images = (new GalleryImage)->find("order: sort_order ASC, id DESC");
+        $this->images = (new GalleryImages)->find("order: sort_order ASC, id DESC");
     }
 }

--- a/default/app/controllers/hemeroteca_controller.php
+++ b/default/app/controllers/hemeroteca_controller.php
@@ -3,9 +3,9 @@ class HemerotecaController extends AppController {
     public function index($year='') {
         if ($year) {
             $this->year = (int)$year;
-            $this->entries = (new HemerotecaEntry)->find("conditions: year={$this->year}", "order: id DESC");
+            $this->entries = (new HemerotecaEntries)->find("conditions: year={$this->year}", "order: id DESC");
         } else {
-            $this->years = (new HemerotecaEntry)->find("columns: DISTINCT year", "order: year DESC");
+            $this->years = (new HemerotecaEntries)->find("columns: DISTINCT year", "order: year DESC");
         }
     }
 }

--- a/default/app/controllers/home_controller.php
+++ b/default/app/controllers/home_controller.php
@@ -1,11 +1,11 @@
 <?php
 class HomeController extends AppController {
     public function index() {
-        $this->key_sections = (new Section)->find("conditions: is_visible=1 AND is_key=1", "order: sort_order ASC");
-        $this->events = (new Event)->find("conditions: status='published' AND start_date >= CURDATE()", "order: start_date ASC", "limit: 6");
-        $this->gallery = (new GalleryImage)->find("order: sort_order ASC, id DESC", "limit: 12");
-        $this->establishments = (new Establishment)->find("conditions: is_active=1", "order: name ASC");
-        $this->years = (new HemerotecaEntry)->find("columns: DISTINCT year", "order: year DESC");
-        $this->menu_extra = (new MenuItem)->find("conditions: is_visible=1", "order: sort_order ASC");
+        $this->key_sections = (new Sections)->find("conditions: is_visible=1 AND is_key=1", "order: sort_order ASC");
+        $this->events = (new Events)->find("conditions: status='published' AND start_date >= CURDATE()", "order: start_date ASC", "limit: 6");
+        $this->gallery = (new GalleryImages)->find("order: sort_order ASC, id DESC", "limit: 12");
+        $this->establishments = (new Establishments)->find("conditions: is_active=1", "order: name ASC");
+        $this->years = (new HemerotecaEntries)->find("columns: DISTINCT year", "order: year DESC");
+        $this->menu_extra = (new MenuItems)->find("conditions: is_visible=1", "order: sort_order ASC");
     }
 }

--- a/default/app/controllers/sections_controller.php
+++ b/default/app/controllers/sections_controller.php
@@ -1,9 +1,9 @@
 <?php
 class SectionsController extends AppController {
     public function show($slug) {
-        $this->section = (new Section)->find_first("conditions: slug = '$slug' AND is_visible=1");
+        $this->section = (new Sections)->find_first("conditions: slug = '$slug' AND is_visible=1");
         if (!$this->section) { Flash::error('Sección no encontrada'); return Router::redirect('/'); }
-        $this->images = (new GalleryImage)->find("conditions: section_id = {$this->section->id}", "order: sort_order ASC, id DESC");
-        $this->events = (new Event)->find("conditions: status='published' AND section_id = {$this->section->id}", "order: start_date ASC");
+        $this->images = (new GalleryImages)->find("conditions: section_id = {$this->section->id}", "order: sort_order ASC, id DESC");
+        $this->events = (new Events)->find("conditions: status='published' AND section_id = {$this->section->id}", "order: start_date ASC");
     }
 }

--- a/default/app/models/establishment.php
+++ b/default/app/models/establishment.php
@@ -1,4 +1,0 @@
-<?php
-class Establishment extends ActiveRecord {
-    // table: establishments
-}

--- a/default/app/models/establishments.php
+++ b/default/app/models/establishments.php
@@ -1,0 +1,4 @@
+<?php
+class Establishments extends ActiveRecord {
+    // table: establishments
+}

--- a/default/app/models/event.php
+++ b/default/app/models/event.php
@@ -1,4 +1,0 @@
-<?php
-class Event extends ActiveRecord {
-    // table: events
-}

--- a/default/app/models/events.php
+++ b/default/app/models/events.php
@@ -1,0 +1,4 @@
+<?php
+class Events extends ActiveRecord {
+    // table: events
+}

--- a/default/app/models/gallery_image.php
+++ b/default/app/models/gallery_image.php
@@ -1,4 +1,0 @@
-<?php
-class GalleryImage extends ActiveRecord {
-    // table: gallery_images
-}

--- a/default/app/models/gallery_images.php
+++ b/default/app/models/gallery_images.php
@@ -1,0 +1,4 @@
+<?php
+class GalleryImages extends ActiveRecord {
+    // table: gallery_images
+}

--- a/default/app/models/hemeroteca_entries.php
+++ b/default/app/models/hemeroteca_entries.php
@@ -1,0 +1,4 @@
+<?php
+class HemerotecaEntries extends ActiveRecord {
+    // table: hemeroteca_entries
+}

--- a/default/app/models/hemeroteca_entry.php
+++ b/default/app/models/hemeroteca_entry.php
@@ -1,4 +1,0 @@
-<?php
-class HemerotecaEntry extends ActiveRecord {
-    // table: hemeroteca_entries
-}

--- a/default/app/models/menu_item.php
+++ b/default/app/models/menu_item.php
@@ -1,4 +1,0 @@
-<?php
-class MenuItem extends ActiveRecord {
-    // table: menu_items
-}

--- a/default/app/models/menu_items.php
+++ b/default/app/models/menu_items.php
@@ -1,0 +1,4 @@
+<?php
+class MenuItems extends ActiveRecord {
+    // table: menu_items
+}

--- a/default/app/models/section.php
+++ b/default/app/models/section.php
@@ -1,4 +1,0 @@
-<?php
-class Section extends ActiveRecord {
-    // table: sections
-}

--- a/default/app/models/sections.php
+++ b/default/app/models/sections.php
@@ -1,0 +1,4 @@
+<?php
+class Sections extends ActiveRecord {
+    // table: sections
+}

--- a/default/app/views/_shared/partials/calendario.phtml
+++ b/default/app/views/_shared/partials/calendario.phtml
@@ -29,7 +29,7 @@
                 <strong><?php echo $ev->title ?></strong>
                 <div class="small text-muted"><?php echo $ev->category ?> · <?php echo date('d/m/Y', strtotime($ev->start_date)) ?></div>
                 <?php if ($ev->place): ?><div class="small"><?php echo $ev->place ?></div><?php endif; ?>
-                <?php if ($ev->section_id): ?><a class="btn btn-sm btn-outline-teal mt-2" href="/sections/show/<?php echo (new Section)->find_first($ev->section_id)->slug ?>">Ver sección</a><?php endif; ?>
+                <?php if ($ev->section_id): ?><a class="btn btn-sm btn-outline-teal mt-2" href="/sections/show/<?php echo (new Sections)->find_first($ev->section_id)->slug ?>">Ver sección</a><?php endif; ?>
               </div>
             <?php endforeach ?>
           </div>

--- a/default/app/views/hemeroteca/index.phtml
+++ b/default/app/views/hemeroteca/index.phtml
@@ -16,7 +16,7 @@
           <strong><?php echo $e->title ?></strong>
           <div class="small text-muted"><?php echo $e->kind ?></div>
           <?php if ($e->file_url): ?><a class="btn btn-sm btn-outline-teal mt-2" href="<?php echo $e->file_url ?>" target="_blank">Abrir</a><?php endif; ?>
-          <?php if ($e->gallery_section_id): ?><a class="btn btn-sm btn-outline-teal mt-2" href="/sections/show/<?php echo (new Section)->find_first($e->gallery_section_id)->slug ?>">Ver galería</a><?php endif; ?>
+          <?php if ($e->gallery_section_id): ?><a class="btn btn-sm btn-outline-teal mt-2" href="/sections/show/<?php echo (new Sections)->find_first($e->gallery_section_id)->slug ?>">Ver galería</a><?php endif; ?>
         </div>
       </div>
     </div>

--- a/default/app/views/home/index.phtml
+++ b/default/app/views/home/index.phtml
@@ -10,7 +10,7 @@
 $ev_json = array_map(function($ev){
   $slug = '';
   if ($ev->section_id) {
-    $s = (new Section)->find_first($ev->section_id);
+    $s = (new Sections)->find_first($ev->section_id);
     if ($s) $slug = $s->slug;
   }
   return [


### PR DESCRIPTION
## Resumen
- Renombrados los modelos para que usen nombres en plural.
- Actualizados controladores y vistas con los nuevos nombres de modelo.

## Pruebas
- `composer install` (falló: CONNECT tunnel failed)
- `vendor/bin/phpunit -c core/phpunit.xml.dist` (falló: No such file or directory)
- `php -l default/app/controllers/establishments_controller.php`
- `php -l default/app/controllers/events_controller.php`
- `php -l default/app/controllers/gallery_controller.php`
- `php -l default/app/controllers/hemeroteca_controller.php`
- `php -l default/app/controllers/home_controller.php`
- `php -l default/app/controllers/sections_controller.php`
- `php -l default/app/models/establishments.php`
- `php -l default/app/models/events.php`
- `php -l default/app/models/gallery_images.php`
- `php -l default/app/models/hemeroteca_entries.php`
- `php -l default/app/models/menu_items.php`
- `php -l default/app/models/sections.php`
- `php -l default/app/views/_shared/partials/calendario.phtml`
- `php -l default/app/views/hemeroteca/index.phtml`
- `php -l default/app/views/home/index.phtml`


------
https://chatgpt.com/codex/tasks/task_e_68aaebcd0b308323960f0c5cae22bbdf